### PR TITLE
テキストエリアのテンプレートを実装、他

### DIFF
--- a/.scaffdog/form-input-text-area.md
+++ b/.scaffdog/form-input-text-area.md
@@ -1,0 +1,241 @@
+---
+name: 'form-input-text-area'
+root: './src/'
+output: '/model/**/components/form-with-preview'
+ignore: []  
+questions:
+  property: 'プロパティ名を入力してください (eg. description)'
+  required:
+    confirm: '公開時 必須項目ですか？'
+    initial: true
+---
+
+# `form/inputs/{{ inputs.property }}/const.ts`
+
+```ts
+{{ model := output.path | extractModel }}
+{{ name := model + '-' + inputs.property }}
+export const {{ name | snake | upper }}_DEFAULT_VALUE = "";
+```
+
+# `form/inputs/{{ inputs.property }}/hook.ts`
+
+```ts
+{{ model := output.path | extractModel }}
+
+import { use{{ model | pascal }}FormStore } from "../../../store/hook";
+
+export const use{{ model | pascal }}{{ inputs.property | pascal }}Input = () => {
+  const value = use{{ model | pascal }}FormStore((state) => state.{{ inputs.property | camel }});
+  const setValue = use{{ model | pascal }}FormStore((state) => state.set{{ inputs.property | pascal }});
+  const validationPhase = use{{ model | pascal }}FormStore(
+    (state) => state.validationPhase,
+  );
+  const getErrorMessages = use{{ model | pascal }}FormStore(
+    (state) => state.get{{ inputs.property | pascal }}ErrorMessages,
+  );
+
+  const errorMessages = getErrorMessages(value, validationPhase);
+
+  return { value, setValue, errorMessages };
+};
+
+```
+
+# `form/inputs/{{ inputs.property }}/index.tsx`
+
+```tsx
+{{ model := output.path | extractModel }}
+
+"use client";
+
+import type { FC } from "react";
+
+import { TextArea } from "@/common/components/form/text-area";
+
+import { use{{ model | pascal }}{{ inputs.property | pascal }}Input } from "./hook";
+
+export const {{ model | pascal }}{{ inputs.property | pascal }}Input: FC = () => {
+  const { value, setValue, errorMessages } = use{{ model | pascal }}{{ inputs.property | pascal }}Input();
+
+  return (
+    <TextArea
+      label=""
+      description=""
+      placeholder=""
+      {{ if inputs.required }}required{{ end }}
+      value={value}
+      setValue={setValue}
+      errorMessages={errorMessages}
+    />
+  );
+};
+
+```
+
+# `form/inputs/{{ inputs.property }}/slice.ts`
+
+```ts
+{{ model := output.path | extractModel }}
+
+import {
+  type ValidationPhase,
+  getValidationtErrorMessage,
+} from "@/model/common/lib/get-validation-error-message";
+import type { FormInputSliceCreater } from "@/model/common/store/form";
+
+import {
+  validate{{ model | pascal }}{{ inputs.property | pascal }}OnChange,
+  validate{{ model | pascal }}{{ inputs.property | pascal }}OnSubmit,
+} from "./validation";
+
+export type {{ model | pascal }}{{ inputs.property | pascal }}Slice = {
+  {{ inputs.property | camel }}: string;
+  set{{ inputs.property | pascal }}: ({{ inputs.property | camel }}: string) => void;
+  get{{ inputs.property | pascal }}ErrorMessages: (
+    value: string,
+    phase: ValidationPhase,
+  ) => string[];
+  get{{ inputs.property | pascal }}IsValid: () => boolean;
+};
+
+export const create{{ model | pascal }}{{ inputs.property | pascal }}Slice: FormInputSliceCreater<
+  {{ model | pascal }}{{ inputs.property | pascal }}Slice,
+  { {{ inputs.property | camel }}: string }
+> = (initalValue) => (set, get) => ({
+  {{ inputs.property | camel }}: initalValue.{{ inputs.property | camel }},
+  set{{ inputs.property | pascal }}: ({{ inputs.property | camel }}) => set({ {{ inputs.property | camel }} }),
+  get{{ inputs.property | pascal }}ErrorMessages: (value, phase) => {
+    return getValidationtErrorMessage({
+      phase,
+      validations: {
+        onChange: validate{{ model | pascal }}{{ inputs.property | pascal }}OnChange(value),
+        onConfirmedSubmit: validate{{ model | pascal }}{{ inputs.property | pascal }}OnSubmit(value),
+      },
+    });
+  },
+  get{{ inputs.property | pascal }}IsValid: () => {
+    const value = get().{{ inputs.property | camel }};
+    const phase = get().validationPhase;
+    const errorMessages = get().get{{ inputs.property | pascal }}ErrorMessages(value, phase);
+    return errorMessages.length === 0;
+  },
+});
+
+```
+
+# `form/inputs/{{ inputs.property }}/validation.ts`
+
+```ts
+{{ model := output.path | extractModel }}
+
+import {
+  maxLengthValidation,
+  notEmptyInputValidation,
+} from "@/common/lib/form-validation/text-input";
+import type { MultiValidationFn } from "@/common/lib/form-validation/type";
+
+export const validate{{ model | pascal }}{{ inputs.property | pascal }}OnSubmit: MultiValidationFn<
+  string
+> = (v) => [notEmptyInputValidation(v)];
+
+export const validate{{ model | pascal }}{{ inputs.property | pascal }}OnChange: MultiValidationFn<
+  string
+> = (v) => [maxLengthValidation(100)(v)];
+
+```
+
+# `form/index.tsx`
+<!-- formを更新 -->
+
+```ts
+{{ model := output.path | extractModel }}
+import { {{ model | pascal }}{{ inputs.property | pascal }}Input } from "./inputs/{{ inputs.property }}";
+
+{{ read output.abs | before "</" }}
+<{{ model | pascal }}{{ inputs.property | pascal }}Input />
+{{ read output.abs | after "</" -1 }}
+
+```
+
+# `form/type.ts`
+<!-- formの型を更新 -->
+
+```ts
+{{ read output.abs | before "};" }}
+  {{ inputs.property | camel }}: string;
+{{ read output.abs | after "};" -1 }}
+
+```
+
+
+# `store/const.ts`
+<!-- formの初期値を更新 -->
+
+```ts
+{{ model := output.path | extractModel }}
+{{ name := model + '-' + inputs.property }}
+import { {{ name | snake | upper }}_DEFAULT_VALUE } from "../form/inputs/{{ inputs.property}}/const"
+
+{{ read output.abs | before "};" }}
+  {{ inputs.property | camel }}: {{ name | snake | upper }}_DEFAULT_VALUE,
+{{ read output.abs | after "};" -1 }}
+
+```
+
+# `store/index.ts`
+<!-- formのstoreを更新 -->
+
+```ts
+{{ model := output.path | extractModel }}
+
+import { create{{ model | pascal }}{{ inputs.property | pascal }}Slice } from "../form/inputs/{{ inputs.property}}/slice"
+
+
+{{ read output.abs | before "getFormValue:" }}
+      ...create{{ model | pascal }}{{ inputs.property | pascal }}Slice(initialState)(set, get, store),
+{{ read output.abs | after "getFormValue:" -1 }}
+
+// TODO: getFormIsValid に get().get{{ inputs.property | pascal }}IsValid() を追加
+```
+
+# `store/type.ts`
+<!-- storeのtypeを更新 -->
+
+```ts
+{{ model := output.path | extractModel }}
+
+import { {{ model | pascal }}{{ inputs.property | pascal }}Slice } from "../form/inputs/{{ inputs.property }}/slice";
+
+{{ read output.abs }}
+// TODO: 次を追加 {{ model | pascal }}{{ inputs.property | pascal }}Slice &
+
+```
+
+# `preview/{{ inputs.property }}/index.tsx`
+
+```tsx
+{{ model := output.path | extractModel }}
+
+import { {{ model | pascal }}{{ inputs.property | pascal }}PreviewView } from "../../../preview/{{ inputs.property }}";
+import { use{{ model | pascal }}FormStore } from "../../store/hook";
+
+export const {{ model | pascal }}{{ inputs.property | pascal }}PreviewContainer = () => {
+  const {{ inputs.property | camel }} = use{{ model | pascal }}FormStore((state) => state.{{ inputs.property | camel }});
+  return <{{ model | pascal }}{{ inputs.property | pascal }}PreviewView value={ {{ inputs.property | camel }}} />;
+};
+
+```
+
+# `../preview/{{ inputs.property }}/index.tsx`
+
+```tsx
+{{ model := output.path | extractModel }}
+
+import { Text } from "@mantine/core";
+
+export const {{ model | pascal }}{{ inputs.property | pascal }}PreviewView = ({ value }: { value: string }) => {
+  return <Text>{value}</Text>;
+};
+
+```

--- a/.scaffdog/model-form-with-preview.md
+++ b/.scaffdog/model-form-with-preview.md
@@ -118,7 +118,7 @@ import {
   validate{{ inputs.model | pascal }}AdminLabelOnSubmit,
 } from "./validation";
 
-export type AdminLabelSlice = {
+export type {{ inputs.model | pascal }}AdminLabelSlice = {
   adminLabel: string;
   setAdminLabel: (adminLabel: string) => void;
   getAdminLabelErrorMessages: (
@@ -129,7 +129,7 @@ export type AdminLabelSlice = {
 };
 
 export const createAdminLabelSlice: FormInputSliceCreater<
-  AdminLabelSlice,
+  {{ inputs.model | pascal }}AdminLabelSlice,
   { adminLabel: string }
 > = (initalValue) => (set, get) => ({
   adminLabel: initalValue.adminLabel,
@@ -1335,10 +1335,10 @@ export const {{ inputs.model | pascal }}FormStoreProvider: FC<{
 ```ts
 import type { CommonFormSlice } from "@/model/common/store/form";
 
-import type { AdminLabelSlice } from "../form/inputs/admin-label/slice";
+import type { {{ inputs.model | pascal }}AdminLabelSlice } from "../form/inputs/admin-label/slice";
 import type { {{ inputs.model | pascal }}Form } from "../form/type";
 
-export type {{ inputs.model | pascal }}FormStore = AdminLabelSlice &
+export type {{ inputs.model | pascal }}FormStore = {{ inputs.model | pascal }}AdminLabelSlice &
 
 CommonFormSlice<{{ inputs.model | pascal }}Form>;
 

--- a/src/common/components/form/text-area/index.tsx
+++ b/src/common/components/form/text-area/index.tsx
@@ -1,0 +1,50 @@
+"use client";
+import { Textarea as TextAreaPremitive } from "@mantine/core";
+import { type ComponentProps, type FC, useCallback } from "react";
+
+import { isEmpty } from "@/common/lib/guard";
+
+import { ErrorMessages } from "../error-messages";
+import { getInputStyles } from "../styles";
+import type { CostomInputProps } from "../type";
+
+type Props = ComponentProps<typeof TextAreaPremitive> &
+  CostomInputProps & {
+    setValue?: (v: string) => void;
+  };
+
+export const TextArea: FC<Props> = ({
+  label,
+  description,
+  errorMessages,
+  setValue,
+  required = false,
+  ref,
+  ...inputProps
+}) => {
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setValue?.(e.currentTarget.value);
+    },
+    [setValue],
+  );
+
+  return (
+    <TextAreaPremitive
+      label={label}
+      aria-label={label ? undefined : "テキストエリア"}
+      description={description}
+      required={required}
+      aria-required={required}
+      onChange={handleChange}
+      error={
+        errorMessages && !isEmpty(errorMessages) ? (
+          <ErrorMessages messages={errorMessages} />
+        ) : null
+      }
+      styles={getInputStyles(!!description)}
+      autosize
+      {...inputProps}
+    />
+  );
+};


### PR DESCRIPTION
# やったこと
- [x]  form-input-text-area

のテンプレートを実装

- adminTitleのsliceにモデルのprefixをつけた